### PR TITLE
Explicitly set CircleCI image to use Ubuntu 20.04 [semver:patch]

### DIFF
--- a/src/jobs/build-drupal-and-deploy-on-wodby.yml
+++ b/src/jobs/build-drupal-and-deploy-on-wodby.yml
@@ -1,7 +1,8 @@
 description: >
   Wodby deployment job for composer based Drupal projects
 
-machine: true
+machine:
+  image: ubuntu-2004:current
 
 parameters:
   wodby_app_uuid:

--- a/src/jobs/wodby-deploy-simple.yml
+++ b/src/jobs/wodby-deploy-simple.yml
@@ -1,7 +1,8 @@
 description: >
   Simple wodby deployment job for composer based Drupal projects
 
-machine: true
+machine:
+  image: ubuntu-2004:current
 
 parameters:
   wodby_instance_uuid:


### PR DESCRIPTION
See CircleCI deprecation: https://circleci.com/docs/2.0/images/linux-vm/14.04-to-20.04-migration/

[semver:patch]